### PR TITLE
Disable renovate for peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "config:base",
         ":separateMajorReleases",
         ":combinePatchMinorReleases",
+        ":disablePeerDependencies",
         ":ignoreUnstable",
         ":prImmediately",
         ":renovatePrefix",


### PR DESCRIPTION
Add config to disable renovate for peer dependencies.   Assuming these are external peers that are provided by another artifact.